### PR TITLE
Add E Stop chains

### DIFF
--- a/mesact/src/libmesact/buildhal.py
+++ b/mesact/src/libmesact/buildhal.py
@@ -292,7 +292,7 @@ def build(parent):
 	externalEstop = False
 	for i in range(6): # test for an external e stop input
 		key = getattr(parent, 'inputPB_' + str(i)).text()
-		if key == 'External E Stop':
+		if key[0:6] == 'E Stop':
 			externalEstop = True
 	if not externalEstop:
 		halContents.append('\n# Standard I/O Block - EStop, Etc\n')

--- a/mesact/src/libmesact/buildio.py
+++ b/mesact/src/libmesact/buildio.py
@@ -187,11 +187,12 @@ def build(parent):
 		#contents.append('#E Stop chain\n')
 		contents.append('net estop-loopin iocontrol.0.user-enable-out => estop-latch.0.ok-in\n')
 		for i in range(len(eStops) - 1):
-			contents.append(f'net estop-latch.{i}.ok-out => estop-latch.{i+1}.ok-in\n')
+			contents.append(f'net estop-{i}-out estop-latch.{i}.ok-out => estop-latch.{i+1}.ok-in\n')
 		contents.append(f'net estop-loopout estop-latch.{len(eStops)-1}.ok-out => iocontrol.0.emc-enable-in\n')
 		#contents.append('#E Stop reset\n')
+		contents.append(f'net estop-reset iocontrol.0.user-request-enable\n')
 		for i in range(len(eStops)):
-			contents.append(f'net estop-{i}-reset iocontrol.0.user-request-enable => estop-latch.{i}.reset \n')
+			contents.append(f'net estop-reset => estop-latch.{i}.reset \n')
 		#contents.append('#E Stop inputs\n')
 		for i in range(len(eStops)):
 			contents.append(f'net remote-estop{i} estop-latch.{i}.fault-in <= {eStops[i]}')

--- a/mesact/src/libmesact/buildio.py
+++ b/mesact/src/libmesact/buildio.py
@@ -140,7 +140,7 @@ def build(parent):
 	# build inputs, check for debounce
 
 	hm2 = ''
-
+	eStops = []
 	for i in range(32):
 		key = getattr(parent, 'inputPB_' + str(i)).text()
 		invert = '-not' if getattr(parent, 'inputInvertCB_' + str(i)).isChecked() else ''
@@ -175,14 +175,28 @@ def build(parent):
 				for i in range(6):
 					if getattr(parent, 'axisCB_' + str(i)).currentData():
 						contents.append('net home-all ' + f'joint.{i}.home-sw-in\n')
-			elif key == 'External E Stop':
-				contents.append('\n# External E-Stop\n')
-				contents.append('loadrt estop_latch\n')
-				contents.append('addf estop-latch.0 servo-thread\n')
-				contents.append('net estop-loopout iocontrol.0.emc-enable-in <= estop-latch.0.ok-out\n')
-				contents.append('net estop-loopin iocontrol.0.user-enable-out => estop-latch.0.ok-in\n')
-				contents.append('net estop-reset iocontrol.0.user-request-enable => estop-latch.0.reset\n')
-				contents.append(f'net remote-estop estop-latch.0.fault-in <= {hm2}\n')
+			elif key[0:6] == 'E Stop':
+				eStops.append(hm2)
+
+	#Build E-Stop Chain
+	if len(eStops) > 0:
+		contents.append('\n# E-Stop\n')
+		contents.append(f'loadrt estop_latch count={len(eStops)}\n')
+		for i in range(len(eStops)):
+			contents.append(f'addf estop-latch.{i} servo-thread\n')
+		#contents.append('#E Stop chain\n')
+		contents.append('net estop-loopin iocontrol.0.user-enable-out => estop-latch.0.ok-in\n')
+		for i in range(len(eStops) - 1):
+			contents.append(f'net estop-latch.{i}.ok-out => estop-latch.{i+1}.ok-in\n')
+		contents.append(f'net estop-loopout estop-latch.{len(eStops)-1}.ok-out => iocontrol.0.emc-enable-in\n')
+		#contents.append('#E Stop reset\n')
+		for i in range(len(eStops)):
+			contents.append(f'net estop-{i}-reset iocontrol.0.user-request-enable => estop-latch.{i}.reset \n')
+		#contents.append('#E Stop inputs\n')
+		for i in range(len(eStops)):
+			contents.append(f'net remote-estop{i} estop-latch.{i}.fault-in <= {eStops[i]}')
+		contents.append('\n')
+
 
 	output_dict = {
 	'Coolant Flood': 'net flood-output iocontrol.0.coolant-flood => ',

--- a/mesact/src/libmesact/buildmenus.py
+++ b/mesact/src/libmesact/buildmenus.py
@@ -26,7 +26,10 @@ inputs = [{'Not Used':'Select'},
 	]},
 	{'Motion':['Probe Input', 'Digital 0', 'Digital 1', 'Digital 2', 'Digital 3']},
 	{'Spindle':['Spindle Amp Fault', 'Spindle Inhibit', 'Spindle Oriented', 'Spindle Orient Fault']},
-	{'I/O Control':['Lube Level', 'Tool Changed', 'Tool Prepared', 'Tool Changer Fault', 'External E Stop']}
+	{'I/O Control':[
+		{'External E Stop':['E Stop 0', 'E Stop 1', 'E Stop 2', 'E Stop 3',
+		'E Stop 4', 'E Stop 5', 'E Stop 6', 'E Stop 7', 'E Stop 8']},
+		'Lube Level', 'Tool Changed', 'Tool Prepared', 'Tool Changer Fault']}
 ]
 
 # {'':['', ]},


### PR DESCRIPTION
I implemented E Stop chains.  This allows for the user to pick a desired number of E Stop inputs and it chains them together so that all of the E Stop signal have to be correct to allow the machine to turn on.

Not sure if I covered all of the parts of doing this correctly, but it seems to work for me.