### PR TITLE
More on Debian packaging

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,149 +1,150 @@
 mesact (1.2.0) unstable; urgency=medium
 
   * Remove firmware from repository
+  * Initial release (Closes: #1027457).
 
  -- John Thornton <dev@gnipsel.com>  Sat, 31 Dec 2022 06:56:02 -0600
 
-mesact (1.1.2) unstable; urgency=medium
+mesact (1.1.2) UNRELEASED; urgency=medium
 
   * Improve loading ini file for 7i92T boards
 
  -- John Thornton <dev@gnipsel.com>  Sat, 10 Dec 2022 08:25:12 -0600
 
-mesact (1.1.1) unstable; urgency=medium
+mesact (1.1.1) UNRELEASED; urgency=medium
 
   * Improved error reporting with excepthook and various bug fixes
 
  -- John Thornton <dev@gnipsel.com>  Tue, 08 Nov 2022 06:27:59 -0600
 
-mesact (1.1.0) unstable; urgency=medium
+mesact (1.1.0) UNRELEASED; urgency=medium
 
   * Add support for Mesa 7i92T board
 
  -- John Thornton <jt@gnipsel.com>  Mon, 31 Oct 2022 07:01:45 -0500
 
-mesact (1.0.0) unstable; urgency=medium
+mesact (1.0.0) UNRELEASED; urgency=medium
 
   * Extra sections, key-values, comments preserved in the ini file
 
  -- John Thornton <jt@gnipsel.com>  Sat, 29 Oct 2022 08:36:58 -0500
 
-mesact (0.7.4) unstable; urgency=medium
+mesact (0.7.4) UNRELEASED; urgency=medium
 
   * Add E-Stop Chain
 
  -- John Thornton <jt@gnipsel.com>  Sat, 15 Oct 2022 06:55:26 -0500
 
-mesact (0.7.3) unstable; urgency=medium
+mesact (0.7.3) UNRELEASED; urgency=medium
 
   * Build joints after axes in ini file
 
  -- John Thornton <jt@gnipsel.com>  Wed, 05 Oct 2022 07:38:08 -0500
 
-mesact (0.7.2) unstable; urgency=medium
+mesact (0.7.2) UNRELEASED; urgency=medium
 
   * Small error fixes
 
  -- John Thornton <jt@gnipsel.com>  Thu, 08 Sep 2022 11:36:40 -0500
 
-mesact (0.7.1) unstable; urgency=medium
+mesact (0.7.1) UNRELEASED; urgency=medium
 
   * Add Mesaflash and LinuxCNC version info, fix preference saving
 
  -- John Thornton <jt@gnipsel.com>  Fri, 19 Aug 2022 07:31:56 -0500
 
-mesact (0.7.0) unstable; urgency=medium
+mesact (0.7.0) UNRELEASED; urgency=medium
 
   * Fix Desktop categories
 
  -- John Thornton <jt@gnipsel.com>  Thu, 30 Jun 2022 07:14:03 -0500
 
-mesact (0.6.5) unstable; urgency=medium
+mesact (0.6.5) UNRELEASED; urgency=medium
 
   * Finish Smart Serial Card Support
 
  -- John Thornton <jt@gnipsel.com>  Tue, 28 Jun 2022 07:24:33 -0500
 
-mesact (0.6.4) unstable; urgency=medium
+mesact (0.6.4) UNRELEASED; urgency=medium
 
   * Improve NIC test and Servo Thread test
 
  -- John Thornton <jt@gnipsel.com>  Tue, 21 Jun 2022 07:19:34 -0500
 
-mesact (0.6.3) unstable; urgency=medium
+mesact (0.6.3) UNRELEASED; urgency=medium
 
   * Add Mesaflash PCI operations
 
  -- John Thornton <jt@gnipsel.com>  Sun, 12 Jun 2022 12:52:25 -0500
 
-mesact (0.6.2) unstable; urgency=medium
+mesact (0.6.2) UNRELEASED; urgency=medium
 
   * Add step and direction spindle
 
  -- John Thornton <jt@gnipsel.com>  Thu, 09 Jun 2022 07:19:48 -0500
 
-mesact (0.6.1) unstable; urgency=medium
+mesact (0.6.1) UNRELEASED; urgency=medium
 
   * Catch all exceptions in a nice way
 
  -- John Thornton <jt@gnipsel.com>  Sat, 21 May 2022 08:02:08 -0500
 
-mesact (0.6.0) unstable; urgency=medium
+mesact (0.6.0) UNRELEASED; urgency=medium
 
   * Add Mesa PDF documents
 
  -- John Thornton <jt@gnipsel.com>  Fri, 20 May 2022 06:26:31 -0500
 
-mesact (0.5.0) unstable; urgency=medium
+mesact (0.5.0) UNRELEASED; urgency=medium
 
   * Add 7i96S I/O
 
  -- John Thornton <jt@gnipsel.com>  Tue, 17 May 2022 07:18:19 -0500
 
-mesact (0.4.5) unstable; urgency=medium
+mesact (0.4.5) UNRELEASED; urgency=medium
 
   * Add support for 7i96S
 
  -- John Thornton <jt@gnipsel.com>  Sun, 15 May 2022 09:40:12 -0500
 
-mesact (0.4.4) unstable; urgency=medium
+mesact (0.4.4) UNRELEASED; urgency=medium
 
   * Add PDF Documents
   * Add auto loading of ini file
 
  -- John Thornton <jt@gnipsel.com>  Wed, 11 May 2022 07:27:28 -0500
 
-mesact (0.4.3) unstable; urgency=medium
+mesact (0.4.3) UNRELEASED; urgency=medium
 
   * add custom stepper driver name save
 
  -- John Thornton <jt@gnipsel.com>  Mon, 02 May 2022 08:52:24 -0500
 
-mesact (0.4.2) unstable; urgency=medium
+mesact (0.4.2) UNRELEASED; urgency=medium
 
   * Fix daughter cards I/O
 
  -- John Thornton <jt@gnipsel.com>  Sun, 24 Apr 2022 07:41:43 -0500
 
-mesact (0.4.1) unstable; urgency=medium
+mesact (0.4.1) UNRELEASED; urgency=medium
 
   * Get I/O working and add download
 
  -- John Thornton <jt@gnipsel.com>  Wed, 20 Apr 2022 07:20:46 -0500
 
-mesact (0.4.0) unstable; urgency=medium
+mesact (0.4.0) UNRELEASED; urgency=medium
 
   * Get most cards axes working
 
  -- John Thornton <jt@gnipsel.com>  Sat, 16 Apr 2022 11:33:50 -0500
 
-mesact (0.3.0) unstable; urgency=medium
+mesact (0.3.0) UNRELEASED; urgency=medium
 
   * 7i76e configuration tested
 
  -- John Thornton <jt@gnipsel.com>  Fri, 15 Apr 2022 06:37:06 -0500
 
-mesact (0.2.0) unstable; urgency=medium
+mesact (0.2.0) UNRELEASED; urgency=medium
 
   * Initial release.
   * Build ini file

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,11 @@
 Source: mesact
 Maintainer: John Thornton <dev@gnipsel.com>
 Build-Depends: debhelper (>= 11.0.0)
-Standards-Version: 4.6.1.0
+Standards-Version: 4.6.2
 Section: utils
 Priority: optional
+Vcs-Browser: https://github.com/jethornton/mesact/
+Vcs-Git: https://github.com/jethornton/mesact/
 Rules-Requires-Root: no
 
 Package: mesact
@@ -12,11 +14,22 @@ Architecture: any
 Depends:  ${misc:Depends},
           python3 (>=3.6),
           python3-pyqt5,
-          zip,
           python3-packaging,
           python3-requests
 Suggests: linuxcnc-uspace,
-          mesaflash
+          mesaflash,
+          zip
 Description: Mesa Configuration Tools for LinuxCNC
- For 5i25/6i25, 7i76e, 7i80, 7i92, 7i95, 7i96, 7i97
- Mesa LinuxCNC motion control boards and daughter cards.
+ Between the program controling the execution of a CNC mill, CNC lathe
+ or a robot, and the powerful drivers that know how to turn a motor,
+ is some glue-hardware required that can trigger the drivers to step
+ or spin. 
+ .
+ It is not uncommon to see the parallel printer port being that trigger.
+ For higher frequencies, and with the confidence of a perfect clock without
+ the involvement of the computer's CPU, a small card may come to the assistance.
+ This may be microcontroller, or as it is for the Mesa cards, an FPGA.
+ .
+ This software knows how to configure LinuxCNC for using one of the 
+ 5i25/6i25, 7i76e, 7i80, 7i92, 7i95, 7i96, 7i97 Mesa LinuxCNC motion control
+ boards and daughter cards.

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,3 @@
+version=4
+opts="repack,repacksuffix=+ds,dersionmangle=auto,filenamemangle=s%(?:.*?)?v?(@ANY_VERSION@@ARCHIVE_EXT@)%@PACKAGE@-$1%" \
+    https://github.com/jethornton/mesact/tags (?:.*?/)v?@ANY_VERSION@@ARCHIVE_EXT@


### PR DESCRIPTION
The lintian error on standard version 4.6.1 being the latest is wrong, the Debian policy changed more quickly than lintian :)

Extended the description of the package, please kindly proofread(+extend/fix?) that.

The changelog now got a ref to an ITP (https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1027457) that I submitted earlier today. From Debian's perspective all releases that have not made it to the official channels are unreleased. I changed d/changelog accordingly, but this may not be what you want.

Concerning the firmwares I like to see them moving to another place. The same holds for the PDFs, I think. I am just uncertain if too many people are unhappy when they have only a single Ethernet slot and just connected the Mesa card to it when they then learn that some file is missing.