### PR TITLE
Ini file update and MDI UI fixes

### DIFF
--- a/mesact/src/libmesact/buildini.py
+++ b/mesact/src/libmesact/buildini.py
@@ -3,6 +3,9 @@ from datetime import datetime
 
 from PyQt5.QtWidgets import QSpinBox
 
+from libmesact import mdi
+
+
 def build(parent):
 	buildErrors = []
 	iniFilePath = os.path.join(parent.configPath, parent.configNameUnderscored + '.ini')
@@ -155,9 +158,10 @@ def build(parent):
 	# build the [HALUI] section
 	if parent.haluiCB.isChecked():
 		iniContents.append('\n[HALUI]\n')
-		for i in range(10):
-			if getattr(parent, f"mdiCmdLE_{i}").text():
-				iniContents.append(f'MDI_COMMAND = {getattr(parent, f"mdiCmdLE_{i}").text()}\n')
+		for i in range(mdi.get_mdi_commands_count(parent)):
+			cmd = mdi.get_mdi_command(parent, i)
+			if cmd:
+				iniContents.append(f'MDI_COMMAND = {cmd}\n')
 
 	# build the axes and joints
 	axes = [] # use only one axis letter with multiple joint axis

--- a/mesact/src/libmesact/check.py
+++ b/mesact/src/libmesact/check.py
@@ -1,3 +1,5 @@
+from libmesact import mdi
+
 
 def checkit(parent):
 	parent.mainTW.setCurrentIndex(11)
@@ -230,13 +232,13 @@ def checkit(parent):
 	# end of SS Cards Tab
 
 	# check the Options Tab for errors
-	mdi = []
-	for i in range(9):
-		cmd = getattr(parent, f'mdiCmdLE_{i}').text()
+	mdi_commands = []
+	for i in range(mdi.get_mdi_commands_count(parent)):
+		cmd = mdi.get_mdi_command(parent, i)
 		if len(cmd) > 0:
-			mdi.append(i)
-	if len(mdi) > 0:
-		if len(mdi) != max(mdi) + 1:
+			mdi_commands.append(i)
+	if len(mdi_commands) > 0:
+		if len(mdi_commands) != max(mdi_commands) + 1:
 			tabError = True
 			configErrors.append(f'\tMDI commands must start at 0 and not skip any')
 		if not parent.haluiCB.isChecked():

--- a/mesact/src/libmesact/combos.py
+++ b/mesact/src/libmesact/combos.py
@@ -110,7 +110,7 @@ def build(parent):
 			parent.editorCB.addItem(key, value)
 	if not installed:
 		parent.editorCB.addItem('None', False)
-		parent.machinePTE.appendPlainText('No Editors were found!')
+		parent.verifyPTE.appendPlainText('No Editors were found!')
 
 	# Joint Tabs
 	axes = [

--- a/mesact/src/libmesact/mdi.py
+++ b/mesact/src/libmesact/mdi.py
@@ -1,0 +1,44 @@
+from PyQt5.QtWidgets import QGridLayout, QLabel, QLineEdit
+
+
+def get_mdi_commands_count(parent):
+    # Workaround for QGridLayout.rowCount() that returns 1 for empty grid
+    grid_layout: QGridLayout = parent.mdiCommandsListGL
+    rows = 0
+    grid_layout.rowCount()
+    for i in range(grid_layout.count()):
+        row, _, span, _ = grid_layout.getItemPosition(i)
+        rows = max(1, row + span)
+    return rows
+
+
+def add_mdi_command_row(parent):
+    grid_layout: QGridLayout = parent.mdiCommandsListGL
+    row = get_mdi_commands_count(parent)
+    label = QLabel(f'MDI Command {row}')
+    grid_layout.addWidget(label, row, 0)
+    text_box = QLineEdit()
+    text_box.setObjectName(__get_mdi_command_control_name(row))
+    grid_layout.addWidget(text_box, row, 1)
+
+
+def set_mdi_command(parent, command_number, value):
+    row_count = get_mdi_commands_count(parent)
+    i = row_count
+    while i <= command_number:
+        add_mdi_command_row(parent)
+        i += 1
+    text_box: QLineEdit = parent.findChild(QLineEdit, __get_mdi_command_control_name(command_number))
+    text_box.setText(value)
+
+
+def get_mdi_command(parent, command_number):
+    rows_count = get_mdi_commands_count(parent)
+    if rows_count == 0 or command_number >= rows_count:
+        return ""
+    text_box: QLineEdit = parent.findChild(QLineEdit, __get_mdi_command_control_name(command_number))
+    return text_box.text()
+
+
+def __get_mdi_command_control_name(command_number):
+    return f'mdiCmdLE_{command_number}'

--- a/mesact/src/libmesact/openini.py
+++ b/mesact/src/libmesact/openini.py
@@ -6,6 +6,8 @@ from PyQt5.QtWidgets import (QFileDialog, QLabel, QLineEdit, QSpinBox,
 
 from libmesact import utilities
 from libmesact import dialogs
+from libmesact import mdi
+
 
 class loadini:
 	def __init__(self):
@@ -191,7 +193,7 @@ class loadini:
 					item = item[1].strip()
 					mdicmd.append(item)
 			for i, item in enumerate(mdicmd):
-				getattr(parent, f'mdiCmdLE_{i}').setText(item)
+				mdi.set_mdi_command(parent, i, item)
 
 		for section in self.sections.items():
 			if section[0].startswith('[JOINT'):

--- a/mesact/src/libmesact/startup.py
+++ b/mesact/src/libmesact/startup.py
@@ -68,6 +68,7 @@ def setup(parent):
 	try: # don't crash if your not running debian
 		emc = subprocess.check_output(['apt-cache', 'policy', 'linuxcnc-uspace'], encoding='UTF-8')
 	except:
+		emc = None
 		pass
 
 	if emc:

--- a/mesact/src/libmesact/updateini.py
+++ b/mesact/src/libmesact/updateini.py
@@ -3,6 +3,9 @@ from datetime import datetime
 
 from PyQt5.QtWidgets import QSpinBox
 
+from libmesact import mdi
+
+
 class updateini:
 	def __init__(self):
 		super().__init__()
@@ -341,15 +344,16 @@ class updateini:
 					if self.content[i].startswith('MDI_COMMAND'):
 						ini_mdi.append(self.content[i].split('=')[1].strip())
 				tool_mdi = []
-				for i in range(10):
-					mdi_text = f'{getattr(parent, f"mdiCmdLE_{i}").text()}'
+				for i in range(mdi.get_mdi_commands_count(parent)):
+					mdi_text = mdi.get_mdi_command(parent, i)
 					if mdi_text:
-						tool_mdi.append(f'{getattr(parent, f"mdiCmdLE_{i}").text()}')
+						tool_mdi.append(mdi_text)
 
 				if len(ini_mdi) == len(tool_mdi):
 					for i, j in enumerate(range(index[0] + 1, index[1])):
 						if self.content[j].startswith('MDI_COMMAND'):
-							self.content[j] = f'MDI_COMMAND = {getattr(parent, f"mdiCmdLE_{i}").text()}\n'
+							cmd = mdi.get_mdi_command(parent, i)
+							self.content[j] = f'MDI_COMMAND = {cmd}\n'
 				elif len(ini_mdi) > len(tool_mdi):
 					remove = len(ini_mdi) - len(tool_mdi)
 					for i in reversed(range(index[0] + 1, index[1])):
@@ -360,10 +364,11 @@ class updateini:
 				elif len(ini_mdi) < len(tool_mdi):
 					add = len(tool_mdi) - len(ini_mdi)
 					for i, j in enumerate(range(index[0] + 1, index[1] + add)):
+						cmd = mdi.get_mdi_command(parent, i)
 						if self.content[j].startswith('MDI_COMMAND'): # replace it
-							self.content[j] = f'MDI_COMMAND = {getattr(parent, f"mdiCmdLE_{i}").text()}\n'
+							self.content[j] = f'MDI_COMMAND = {cmd}\n'
 						elif self.content[j].strip() == '': # insert it
-							self.content.insert(j, f'MDI_COMMAND = {getattr(parent, f"mdiCmdLE_{i}").text()}\n')
+							self.content.insert(j, f'MDI_COMMAND = {cmd}\n')
 					self.get_sections() # update section start/end
 
 		############ Massive rework needed here

--- a/mesact/src/mesact
+++ b/mesact/src/mesact
@@ -46,6 +46,7 @@ from libmesact import settings
 from libmesact import spindle
 from libmesact import shutdown
 from libmesact import updates
+from libmesact import mdi
 
 # testing imports
 from libmesact import testing
@@ -225,6 +226,12 @@ class MainWindow(QMainWindow):
 		#self.load_config_cb.toggled.connect(partial(settings.update_settings, self))
 		#self.checkMesaflashCB.clicked.connect(partial(settings.update_value, self))
 		#self.newUserCB.clicked.connect(partial(settings.update_value, self))
+
+		# Options Tab - MDI
+		for i in range(10):
+			mdi.add_mdi_command_row(self)
+
+		self.addMdiCommandPB.clicked.connect(partial(mdi.add_mdi_command_row, self))
 
 	def changed(self):
 		#if isinstance(self.sender(), QComboBox):

--- a/mesact/src/mesact.ui
+++ b/mesact/src/mesact.ui
@@ -41277,8 +41277,8 @@ to File Open in Axis</string>
              <rect>
               <x>10</x>
               <y>10</y>
-              <width>441</width>
-              <height>401</height>
+              <width>501</width>
+              <height>431</height>
              </rect>
             </property>
             <property name="title">
@@ -41291,59 +41291,6 @@ to File Open in Axis</string>
              <bool>false</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout_312">
-             <item row="3" column="0">
-              <widget class="QLabel" name="label_1386">
-               <property name="text">
-                <string>MDI Command 2</string>
-               </property>
-              </widget>
-             </item>
-             <item row="8" column="1">
-              <widget class="QLineEdit" name="mdiCmdLE_7"/>
-             </item>
-             <item row="3" column="1">
-              <widget class="QLineEdit" name="mdiCmdLE_2"/>
-             </item>
-             <item row="7" column="1">
-              <widget class="QLineEdit" name="mdiCmdLE_6"/>
-             </item>
-             <item row="1" column="1">
-              <widget class="QLineEdit" name="mdiCmdLE_0"/>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="label_1380">
-               <property name="text">
-                <string>MDI Command 1</string>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="0">
-              <widget class="QLabel" name="label_1390">
-               <property name="text">
-                <string>MDI Command 5</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="0">
-              <widget class="QLabel" name="label_1389">
-               <property name="text">
-                <string>MDI Command 4</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="1">
-              <widget class="QLineEdit" name="mdiCmdLE_4"/>
-             </item>
-             <item row="4" column="1">
-              <widget class="QLineEdit" name="mdiCmdLE_3"/>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_1310">
-               <property name="text">
-                <string>MDI Command 0</string>
-               </property>
-              </widget>
-             </item>
              <item row="0" column="0" colspan="2">
               <widget class="QLabel" name="label_1391">
                <property name="frameShape">
@@ -41357,51 +41304,29 @@ to File Open in Axis</string>
                </property>
               </widget>
              </item>
-             <item row="9" column="1">
-              <widget class="QLineEdit" name="mdiCmdLE_8"/>
-             </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="label_1388">
+             <item row="2" column="0">
+              <widget class="QPushButton" name="addMdiCommandPB">
                <property name="text">
-                <string>MDI Command 3</string>
+                <string>Add MDI Command</string>
                </property>
               </widget>
              </item>
-             <item row="6" column="1">
-              <widget class="QLineEdit" name="mdiCmdLE_5"/>
-             </item>
-             <item row="2" column="1">
-              <widget class="QLineEdit" name="mdiCmdLE_1"/>
-             </item>
-             <item row="10" column="1">
-              <widget class="QLineEdit" name="mdiCmdLE_9"/>
-             </item>
-             <item row="7" column="0">
-              <widget class="QLabel" name="label_1441">
-               <property name="text">
-                <string>MDI Command 6</string>
+             <item row="1" column="0">
+              <widget class="QScrollArea" name="scrollArea">
+               <property name="widgetResizable">
+                <bool>true</bool>
                </property>
-              </widget>
-             </item>
-             <item row="8" column="0">
-              <widget class="QLabel" name="label_1442">
-               <property name="text">
-                <string>MDI Command 7</string>
-               </property>
-              </widget>
-             </item>
-             <item row="9" column="0">
-              <widget class="QLabel" name="label_1443">
-               <property name="text">
-                <string>MDI Command 8</string>
-               </property>
-              </widget>
-             </item>
-             <item row="10" column="0">
-              <widget class="QLabel" name="label_1444">
-               <property name="text">
-                <string>MDI Command 9</string>
-               </property>
+               <widget class="QWidget" name="scrollAreaWidgetContents">
+                <property name="geometry">
+                 <rect>
+                  <x>0</x>
+                  <y>0</y>
+                  <width>473</width>
+                  <height>345</height>
+                 </rect>
+                </property>
+                <layout class="QGridLayout" name="mdiCommandsListGL"/>
+               </widget>
               </widget>
              </item>
             </layout>


### PR DESCRIPTION
Fixes in PR:

* Allow to run `mesact` under Windows. Communication with Mesa card not checked, but this fix allows to develop UI.
* Update MDI UI to support dynamic amount of the MDI Commands. New commands can be added with "Add MDI Command" button.
* Fix incorrect `[HAL]` section updating for ini file.
  * Avoid `postgui.hal` and `custom.hal` duplicates
  * Use correct keys for `postgui.hal` and `shutdown.hal`