### PR TITLE
Fix mesact run under Windows.

### DIFF
--- a/mesact/src/libmesact/startup.py
+++ b/mesact/src/libmesact/startup.py
@@ -68,6 +68,7 @@ def setup(parent):
 	try: # don't crash if your not running debian
 		emc = subprocess.check_output(['apt-cache', 'policy', 'linuxcnc-uspace'], encoding='UTF-8')
 	except:
+		emc = None
 		pass
 
 	if emc:


### PR DESCRIPTION
Allow to run mesact under Windows. Communication with Mesa card not checked, but this fix allows to develop UI.